### PR TITLE
fix new cache instance cannot clean expired cache item

### DIFF
--- a/lib/Phpfastcache/Extensions/Drivers/Ravendb/Config.php
+++ b/lib/Phpfastcache/Extensions/Drivers/Ravendb/Config.php
@@ -169,17 +169,6 @@ class Config extends ConfigurationOption
         return $this->serializeData;
     }
 
-    /**
-     * @param bool $serializeData
-     * @return self
-     * @throws PhpfastcacheInvalidArgumentException
-     * @throws PhpfastcacheLogicException
-     */
-    public function setSerializeData(bool $serializeData): static
-    {
-        return $this->setProperty('serializeData', $serializeData);
-    }
-
     public function getAuthOptions(): ?AuthOptions
     {
         return $this->authOptions;

--- a/lib/Phpfastcache/Extensions/Drivers/Ravendb/Driver.php
+++ b/lib/Phpfastcache/Extensions/Drivers/Ravendb/Driver.php
@@ -127,7 +127,6 @@ HELP;
 
         if ($ravenDocument instanceof RavenProxy) {
             $ravenDocument->setDetailedDate($this->getConfig()->isItemDetailedDate());
-            $ravenDocument->setSerializeData($this->getConfig()->isSerializeData());
             return $ravenDocument;
         }
 

--- a/lib/Phpfastcache/Extensions/Drivers/Ravendb/RavenProxy.php
+++ b/lib/Phpfastcache/Extensions/Drivers/Ravendb/RavenProxy.php
@@ -41,7 +41,7 @@ class RavenProxy
 
     protected ?\DateTimeInterface $modificationDate = null;
 
-    public function __construct(?ExtendedCacheItemInterface $item = null, protected bool $serializeData = true, protected bool $detailedDate = false)
+    public function __construct(?ExtendedCacheItemInterface $item = null, protected bool $detailedDate = false)
     {
         if ($item) {
             $this->fromCacheItem($item);
@@ -70,8 +70,7 @@ class RavenProxy
 
     public function setData(mixed $data): self
     {
-        $this->data = $this->serializeData ? serialize($data) : $data;
-
+        $this->data = $data;
         return $this;
     }
 
@@ -133,8 +132,10 @@ class RavenProxy
         }
 
         $this->setData($item->_getData())
-            ->setExpirationDate($item->getExpirationDate())
-            ->setTags($item->getTags());
+        ->setExpirationDate($item->getExpirationDate())
+        ->setCreationDate($item->getCreationDate())
+        ->setModificationDate($item->getModificationDate())
+        ->setTags($item->getTags());
 
         if ($this->detailedDate) {
             $this->setModificationDate($item->getModificationDate())
@@ -150,7 +151,7 @@ class RavenProxy
         if ($this->key) {
             return [
                 ExtendedCacheItemPoolInterface::DRIVER_KEY_WRAPPER_INDEX => $this->key,
-                ExtendedCacheItemPoolInterface::DRIVER_DATA_WRAPPER_INDEX => ($this->serializeData ? unserialize($this->data) : $this->data),
+                ExtendedCacheItemPoolInterface::DRIVER_DATA_WRAPPER_INDEX => $this->data,
                 ExtendedCacheItemPoolInterface::DRIVER_EDATE_WRAPPER_INDEX => $this->expirationDate,
                 ExtendedCacheItemPoolInterface::DRIVER_CDATE_WRAPPER_INDEX => $this->creationDate,
                 ExtendedCacheItemPoolInterface::DRIVER_MDATE_WRAPPER_INDEX => $this->modificationDate,
@@ -158,11 +159,6 @@ class RavenProxy
             ];
         }
         return null;
-    }
-
-    public function setSerializeData(bool $serializeData): void
-    {
-        $this->serializeData = $serializeData;
     }
 
     public function setDetailedDate(bool $detailedDate): void

--- a/tests/Configs/github-actions.php
+++ b/tests/Configs/github-actions.php
@@ -3,7 +3,6 @@
 use Phpfastcache\Drivers\Ravendb\Config as RavendbConfig;
 
 return (new RavendbConfig())
-    ->setSerializeData(false)
     ->setItemDetailedDate(true)
     ->setHost([getenv('RAVENDB_TEST_DATABASE_HOSTNAME') ?: 'http://127.0.0.1:8082'])
     ->setCollectionName('phpfastcache')


### PR DESCRIPTION
When starting a new cache instance, with already cached item in ravendb, we would get a error. 
That was happening because after loading the document from ravendb, in the php client we would create an entity from document that was returned from ravendb server, and it would use the `RavenProxy` constructor with `$serializeData = true` and this would create the entity with wrong data in `data` field, since the `serialize($data)` was used. So instead of `data: "First product"` we would get `data: "s:13:"FirstProduct"`. Then when we try to delete this document, we would get an exception since the tracked entity is changed.